### PR TITLE
fix: move bluesky provider to a dynamic component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useBskyAuthContext } from "@/contexts/bskyAuthProvider";
+import { useBskyAuthContext } from "@/contexts/bluesky";
 import { useCallback, useState } from "react";
 
 export default function Home() {

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { BskyAuthProvider } from "@/contexts/bskyAuthProvider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { useState } from "react";
+import dynamic from "next/dynamic";
 
-export default function RootProviders({
+export default function RootProviders ({
   children,
 }: Readonly<{
   children: React.ReactNode;
@@ -21,6 +21,11 @@ export default function RootProviders({
         },
       })
   );
+
+  const BskyAuthProvider = dynamic(() => import('../components/BskyAuthProvider'), {
+    loading: () => <p>Loading...</p>,
+    ssr: false
+  })
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/components/BskyAuthProvider.tsx
+++ b/src/components/BskyAuthProvider.tsx
@@ -1,36 +1,23 @@
+'use client'
+
+import { BskyAuthContext } from "@/contexts";
 import { Agent } from "@atproto/api";
-import { ProfileViewBasic } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
 import {
   OAuthSession,
   BrowserOAuthClient,
 } from "@atproto/oauth-client-browser";
 import { useQuery } from "@tanstack/react-query";
 import {
-  createContext,
   JSX,
   ReactNode,
-  useContext,
   useEffect,
   useMemo,
   useState,
 } from "react";
 
-type BskyAuthContextProps = {
-  authenticated: boolean;
-  session?: OAuthSession;
-  state?: string;
-  userProfile?: ProfileViewBasic;
-  bskyAuthClient?: BrowserOAuthClient;
-};
-
-const BskyAuthContext = createContext<BskyAuthContextProps>({
-  authenticated: false,
-});
-
 type Props = {
   children: JSX.Element | JSX.Element[] | ReactNode;
 };
-
 export const BskyAuthProvider = ({ children }: Props) => {
   const [authenticated, setAuthenticated] = useState<boolean>(false);
   const [bskyAuthClient, setBskyAuthClient] = useState<BrowserOAuthClient>();
@@ -104,6 +91,4 @@ export const BskyAuthProvider = ({ children }: Props) => {
   );
 };
 
-export const useBskyAuthContext = () => {
-  return useContext(BskyAuthContext);
-};
+export default BskyAuthProvider

--- a/src/contexts/bluesky.tsx
+++ b/src/contexts/bluesky.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { ProfileViewBasic } from "@atproto/api/dist/client/types/app/bsky/actor/defs";
+import {
+  OAuthSession,
+  BrowserOAuthClient,
+} from "@atproto/oauth-client-browser";
+
+import {
+  createContext,
+  useContext,
+} from "react";
+
+type BskyAuthContextProps = {
+  authenticated: boolean;
+  session?: OAuthSession;
+  state?: string;
+  userProfile?: ProfileViewBasic;
+  bskyAuthClient?: BrowserOAuthClient;
+};
+
+export const BskyAuthContext = createContext<BskyAuthContextProps>({
+  authenticated: false,
+});
+
+export const useBskyAuthContext = () => {
+  return useContext(BskyAuthContext);
+};

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -1,1 +1,1 @@
-export * from "./bskyAuthProvider";
+export * from "./bluesky";


### PR DESCRIPTION
the Bluesky client oauth library can't even be loaded by server side components (https://github.com/bluesky-social/atproto/issues/3543) so move it to a dynamic component to fix builds