### PR TITLE
feat: implement plcOperation in the migration/restore flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 
 # wrangler
 .wrangler
+.env

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
   },
   "dependencies": {
     "@atproto/api": "^0.13.35",
+    "@atproto/crypto": "^0.4.4",
     "@atproto/oauth-client-browser": "^0.3.9",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
-    "@tailwindcss/postcss": "^4.0.9",
     "@ipld/dag-ucan": "^3.4.5",
+    "@tailwindcss/postcss": "^4.0.9",
     "@tanstack/react-query": "^5.66.0",
     "@ucanto/client": "^9.0.1",
     "@ucanto/transport": "^9.1.1",
@@ -31,7 +32,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-hook-form": "^7.54.2",
-    "tailwindcss": "^4.0.9"
+    "tailwindcss": "^4.0.9",
+    "uint8arrays": "^5.1.0"
   },
   "devDependencies": {
     "@cloudflare/next-on-pages": "^1.13.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@atproto/api':
         specifier: ^0.13.35
         version: 0.13.35
+      '@atproto/crypto':
+        specifier: ^0.4.4
+        version: 0.4.4
       '@atproto/oauth-client-browser':
         specifier: ^0.3.9
         version: 0.3.10
@@ -20,12 +23,12 @@ importers:
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@18.3.1)
-      '@tailwindcss/postcss':
-        specifier: ^4.0.9
-        version: 4.0.9
       '@ipld/dag-ucan':
         specifier: ^3.4.5
         version: 3.4.5
+      '@tailwindcss/postcss':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@tanstack/react-query':
         specifier: ^5.66.0
         version: 5.66.0(react@18.3.1)
@@ -65,6 +68,9 @@ importers:
       tailwindcss:
         specifier: ^4.0.9
         version: 4.0.9
+      uint8arrays:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@cloudflare/next-on-pages':
         specifier: ^1.13.7
@@ -141,6 +147,10 @@ packages:
 
   '@atproto/common-web@0.4.0':
     resolution: {integrity: sha512-ZYL0P9myHybNgwh/hBY0HaBzqiLR1B5/ie5bJpLQAg0whRzNA28t8/nU2vh99tbsWcAF0LOD29M8++LyENJLNQ==}
+
+  '@atproto/crypto@0.4.4':
+    resolution: {integrity: sha512-Yq9+crJ7WQl7sxStVpHgie5Z51R05etaK9DLWYG/7bR5T4bhdcIgF6IfklLShtZwLYdVVj+K15s0BqW9a8PSDA==}
+    engines: {node: '>=18.7.0'}
 
   '@atproto/did@0.1.5':
     resolution: {integrity: sha512-8+1D08QdGE5TF0bB0vV8HLVrVZJeLNITpRTUVEoABNMRaUS7CoYSVb0+JNQDeJIVmqMjOL8dOjvCUDkp3gEaGQ==}
@@ -3623,6 +3633,12 @@ snapshots:
       multiformats: 9.9.0
       uint8arrays: 3.0.0
       zod: 3.24.2
+
+  '@atproto/crypto@0.4.4':
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      uint8arrays: 3.0.0
 
   '@atproto/did@0.1.5':
     dependencies:

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -8,7 +8,7 @@ const BskyAuthProvider = dynamic(() => import('../components/BlueskyAuthProvider
   ssr: false
 })
 
-const W3UIProvider = dynamic(() => import('../components/W3UIProvider'), {
+const StorachaProvider = dynamic(() => import('../components/StorachaProvider'), {
   loading: () => <p>Loading...</p>,
   ssr: false
 })
@@ -34,9 +34,9 @@ export default function RootProviders({
   return (
     <QueryClientProvider client={queryClient}>
       <BskyAuthProvider>
-        <W3UIProvider>
+        <StorachaProvider>
           {children}
-        </W3UIProvider>
+        </StorachaProvider>
       </BskyAuthProvider>
     </QueryClientProvider>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,10 +1,19 @@
 "use client";
-
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React, { useState } from "react";
 import dynamic from "next/dynamic";
 
-export default function RootProviders ({
+const BskyAuthProvider = dynamic(() => import('../components/BlueskyAuthProvider'), {
+  loading: () => <p>Loading...</p>,
+  ssr: false
+})
+
+const W3UIProvider = dynamic(() => import('../components/W3UIProvider'), {
+  loading: () => <p>Loading...</p>,
+  ssr: false
+})
+
+export default function RootProviders({
   children,
 }: Readonly<{
   children: React.ReactNode;
@@ -22,22 +31,12 @@ export default function RootProviders ({
       })
   );
 
-  const BskyAuthProvider = dynamic(() => import('../components/BlueskyAuthProvider'), {
-    loading: () => <p>Loading...</p>,
-    ssr: false
-  })
-
-  const StorachaAuthProvider = dynamic(() => import('../components/W3UIProvider'), {
-    loading: () => <p>Loading...</p>,
-    ssr: false
-  })
-
   return (
     <QueryClientProvider client={queryClient}>
       <BskyAuthProvider>
-        <StorachaAuthProvider>
+        <W3UIProvider>
           {children}
-        </StorachaAuthProvider>
+        </W3UIProvider>
       </BskyAuthProvider>
     </QueryClientProvider>
   );

--- a/src/components/BackupButton.tsx
+++ b/src/components/BackupButton.tsx
@@ -3,7 +3,7 @@
 import { useBskyAuthContext } from "@/contexts"
 import { backup, BackupMetadataStore } from "@/lib/bluesky"
 import { Space, useW3 } from "@w3ui/react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { SpaceFinder } from "./SpaceFinder"
 import db from "@/app/db"
 import { useLocalPdsSession } from "@/lib/local-pds-session"
@@ -48,12 +48,11 @@ export default function BackupButton () {
       console.log('not backing up, profile, agent, client:', bluesky.userProfile, bluesky.agent, storacha.client)
     }
   }
-useEffect(() => {
-  // setLocalSession()
-}, [])
   // if there are no existing spaces, create a default one
   const createDefaultSpace = () => storacha.client?.createSpace("Space 1", { account: storacha.accounts?.[0] })
-  const userAuthenticatedToBothServices = (bluesky.userProfile || session?.pdSession) && (storacha.accounts.length > 0)
+  const userAuthenticatedToBothServices =
+    (bluesky.userProfile || session?.pdSession) &&
+    (storacha.accounts?.length > 0)
   const [backupProgressComponent, setBackupProgressComponent] = useState(
     <>
       Backing up your Bluesky account...

--- a/src/components/BlueskyAuthenticator.tsx
+++ b/src/components/BlueskyAuthenticator.tsx
@@ -1,13 +1,22 @@
 "use client";
 
 import { useBskyAuthContext } from "@/contexts";
-import { REQUIRED_ATPROTO_SCOPE } from "@/lib/constants";
+import { ATPROTO_DEFAULT_SINK, REQUIRED_ATPROTO_SCOPE } from "@/lib/constants";
 import { useCallback, useState } from "react";
+import { AtprotoLoginForm, LoginFn } from "./RestoreUI";
+import { Agent, CredentialSession } from "@atproto/api";
+import { useLocalPdsSession } from "@/lib/local-pds-session";
 
 export default function BlueskyAuthenticator () {
   const { initialized, authenticated, bskyAuthClient, userProfile, session } = useBskyAuthContext();
+  const { session: localCredSession } = useLocalPdsSession()
 
   const [handle, setHandle] = useState<string>("");
+  const [hasPds, setHasPds] = useState<boolean>(false);
+  const [, setSinkAgent] = useState<Agent>()
+  const [sinkSession, setSinkSession] = useState<CredentialSession | undefined>(
+    localCredSession?.pdSession
+  )
 
   const signIn = useCallback(async () => {
     if (!bskyAuthClient) return;
@@ -20,29 +29,68 @@ export default function BlueskyAuthenticator () {
     }
   }, [handle, bskyAuthClient]);
 
+  const loginToSink: LoginFn = async (identifier, password, { server = ATPROTO_DEFAULT_SINK } = { server: ATPROTO_DEFAULT_SINK }) => {
+    const session = new CredentialSession(new URL(server));
+    await session.login({ identifier, password });
+    const agent = new Agent(session);
+    setSinkSession(session);
+    setSinkAgent(agent);
+
+    const sessionData = {
+      serviceUrl: session.serviceUrl.toString(),
+      session: {
+        handle: session?.session?.handle,
+        did: session?.session?.did,
+        accessJwt: session?.session?.accessJwt,
+        refreshJwt: session?.session?.refreshJwt,
+      }
+    };
+    localStorage.setItem("localSession", JSON.stringify(sessionData));
+  };
+
   return (
     <div>
       {initialized ? (
-        authenticated ? (
+        authenticated || sinkSession ? (
           <div>
-            Authenticated to Bluesky as {userProfile?.handle} on {session?.serverMetadata.issuer}
+            {sinkSession ? (
+              <p className="text-sm">
+                Authenticated to your new Bluesky host <b>{sinkSession.serviceUrl.origin && new URL(sinkSession.serviceUrl.origin).hostname}</b> as <b>{sinkSession.session?.handle}</b>
+              </p>
+            ) : (
+              <p className="text-sm">
+                Authenticated to Bluesky as <b>{userProfile?.handle}</b> on <b>{session?.serverMetadata.issuer}</b>
+              </p>
+            )}
           </div>
         ) : (
           <div>
-            <input
-              onChange={(e) => {
-                e.preventDefault();
-                setHandle(e.target.value);
-              }}
-              value={handle}
-              placeholder="Full Bluesky Handle (eg, racha.bsky.social)"
-              className="ipt w-82"
-            />
-            <button
-              onClick={signIn}
-              className="btn">
-              Sign in
-            </button>
+              <input
+                onChange={(e) => {
+                  e.preventDefault();
+                  setHandle(e.target.value);
+                }}
+                value={handle}
+                placeholder="Full Bluesky Handle (eg, racha.bsky.social)"
+                className="ipt w-82"
+              />
+              <button
+                onClick={signIn}
+                className="btn">
+                  Sign in
+              </button>
+
+              <div className="mt-2 w-100">
+                <p className="text-sm">
+                  Click the button below to login via your PDS
+                </p>
+                <button className="btn" onClick={() => setHasPds(true)}>Login with PDS</button>
+                {hasPds && (
+                  <div className="mt-4">
+                    <AtprotoLoginForm login={loginToSink} defaultServer={ATPROTO_DEFAULT_SINK} />
+                  </div>
+                )}
+              </div>
           </div>
         )) : (
         <div>Loading...</div>

--- a/src/components/RestoreUI.tsx
+++ b/src/components/RestoreUI.tsx
@@ -145,7 +145,6 @@ export default function RestoreButton ({ backupId }: { backupId: string }) {
       const recoveryKey = await Secp256k1Keypair.create({ exportable: true });
       const privateKeyBytes = await recoveryKey.export()
       const privateKey = ui8.toString(privateKeyBytes, "hex")
-      setFinalRecoveryKey(privateKey)
 
       const credentials = await sinkAgent.com.atproto.identity.getRecommendedDidCredentials();
       const rotationKeys = credentials.data.rotationKeys ?? []
@@ -161,15 +160,17 @@ export default function RestoreButton ({ backupId }: { backupId: string }) {
         `❗ Your private recovery key is: ${privateKey}. Please store this in a secure location! ❗`,
       )
 
-      await sinkAgent.com.atproto.identity.submitPlcOperation({
+     const submitPlcOp = await sinkAgent.com.atproto.identity.submitPlcOperation({
         operation: plcOp.data.operation
       })
       await sinkAgent.com.atproto.server.activateAccount()
+      if (submitPlcOp.success){
+        setFinalRecoveryKey(privateKey)
+      }
     } catch (error) {
-      console.error(`Restor failed: ${(error as Error).message}`)
+      console.error(`Restore failed: ${(error as Error).message}`)
       alert(`Restore failed: ${error instanceof Error ? error.message : 'Unknown error'}`)
     }
-
   }
   return (
     <div>

--- a/src/components/RestoreUI.tsx
+++ b/src/components/RestoreUI.tsx
@@ -11,7 +11,7 @@ import { useForm } from "react-hook-form"
 import { Secp256k1Keypair } from "@atproto/crypto"
 import * as ui8 from "uint8arrays"
 
-type LoginFn = (identifier: string, password: string, options?: { server?: string }) => Promise<void>
+export type LoginFn = (identifier: string, password: string, options?: { server?: string }) => Promise<void>
 
 interface LoginForm {
   handle: string
@@ -213,7 +213,7 @@ export default function RestoreButton ({ backupId }: { backupId: string }) {
                   type="text"
                   value={plcToken}
                   placeholder="Please enter token from email"
-                  className="ipt w-full"
+                  className="ipt w-100"
                   onChange={(e: ChangeEvent<HTMLInputElement>) => setPlcToken(e.target.value)}
                 />
                 <button onClick={restore} className="btn">
@@ -249,7 +249,7 @@ export default function RestoreButton ({ backupId }: { backupId: string }) {
   )
 }
 
-function AtprotoLoginForm ({ login, defaultServer }: AtprotoLoginFormProps) {
+export function AtprotoLoginForm ({ login, defaultServer }: AtprotoLoginFormProps) {
   const {
     register,
     handleSubmit,

--- a/src/components/StorachaProvider.tsx
+++ b/src/components/StorachaProvider.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { Provider } from '@w3ui/react'
 import { serviceConnection, servicePrincipal } from './services'
 
-export default function W3UIProvider ({ children }: { children: ReactNode }) {
+export default function StorachaProvider ({ children }: { children: ReactNode }) {
   return (
     <Provider
       connection={serviceConnection}

--- a/src/components/W3UIProvider.tsx
+++ b/src/components/W3UIProvider.tsx
@@ -8,7 +8,7 @@ export default function W3UIProvider ({ children }: { children: ReactNode }) {
       connection={serviceConnection}
       servicePrincipal={servicePrincipal}
     >
-      <>{children}</>
+      {children}
     </Provider>
   )
 }

--- a/src/lib/bluesky.ts
+++ b/src/lib/bluesky.ts
@@ -3,7 +3,7 @@ import { ProfileViewBasic } from "@atproto/api/dist/client/types/app/bsky/actor/
 import { OAuthClientMetadataInput } from "@atproto/oauth-client-browser";
 import { CARLink, Client } from "@w3ui/react";
 
-export const blueskyClientUri = process.env.NEXT_PUBLIC_BLUESKY_CLIENT_URI || "https://localhost:3000/"
+export const blueskyClientUri = process.env.NEXT_PUBLIC_BLUESKY_CLIENT_URI! || "https://localhost:3000/"
 
 export const blueskyClientMetadata: OAuthClientMetadataInput = {
     "client_id": `${blueskyClientUri}bluesky-client-metadata`,

--- a/src/lib/local-pds-session.ts
+++ b/src/lib/local-pds-session.ts
@@ -1,4 +1,5 @@
 import { CredentialSession, Agent } from "@atproto/api";
+import { useState } from "react";
 
 export type LocalSession = {
   pdSession: CredentialSession;
@@ -6,22 +7,25 @@ export type LocalSession = {
 };
 
 export const useLocalPdsSession = () => {
-  if (typeof window === "undefined") return { session: undefined };
+  const getSession = (): LocalSession | undefined => {
+    if (typeof window === "undefined") return undefined
+    const localSesh = localStorage.getItem("localSession")
+    if (!localSesh) return undefined
 
-  const localSesh = localStorage.getItem("localSession");
-  if (!localSesh) return { session: undefined };
-
-  try {
-    const sessionData = JSON.parse(localSesh);
-    const serviceUrl = new URL(sessionData.serviceUrl);
-    const session = new CredentialSession(serviceUrl);
-
-    session.session = sessionData.session;
-    const agent = new Agent(session);
-
-    return { session: { pdSession: session, pdAgent: agent } };
-  } catch (error) {
-    console.error("Error restoring session:", error);
-    return { session: undefined };
+    try {
+      const sessionData = JSON.parse(localSesh)
+      const serviceUrl = new URL(sessionData.serviceUrl)
+      const session = new CredentialSession(serviceUrl)
+      session.session = sessionData.session
+      const agent = new Agent(session)
+      return { pdSession: session, pdAgent: agent }
+    } catch (error) {
+      console.error("Error restoring session:", error)
+      return undefined
+    }
   }
-};
+
+  const [session] = useState<LocalSession | undefined>(getSession())
+
+  return { session }
+}

--- a/src/lib/local-pds-session.ts
+++ b/src/lib/local-pds-session.ts
@@ -1,0 +1,27 @@
+import { CredentialSession, Agent } from "@atproto/api";
+
+export type LocalSession = {
+  pdSession: CredentialSession;
+  pdAgent: Agent;
+};
+
+export const useLocalPdsSession = () => {
+  if (typeof window === "undefined") return { session: undefined };
+
+  const localSesh = localStorage.getItem("localSession");
+  if (!localSesh) return { session: undefined };
+
+  try {
+    const sessionData = JSON.parse(localSesh);
+    const serviceUrl = new URL(sessionData.serviceUrl);
+    const session = new CredentialSession(serviceUrl);
+
+    session.session = sessionData.session;
+    const agent = new Agent(session);
+
+    return { session: { pdSession: session, pdAgent: agent } };
+  } catch (error) {
+    console.error("Error restoring session:", error);
+    return { session: undefined };
+  }
+};


### PR DESCRIPTION
For this restore flow to work as it should we need an additional security token because identity ops are very sensitive.

When the restore button is clicked, we ask for that token, which we'll, in turn, need for the `plcOperation` along the line.