### PR TITLE
fix: Move deprecated components in SpaceFinder

### DIFF
--- a/src/components/SpaceFinder.tsx
+++ b/src/components/SpaceFinder.tsx
@@ -1,35 +1,42 @@
 // copied from console
 
-import type { Space } from '@w3ui/react'
+import type { Space } from "@w3ui/react";
 
-import React, { Fragment, useState } from 'react'
-import { Combobox, Transition } from '@headlessui/react'
-import { ChevronUpDownIcon } from '@heroicons/react/20/solid'
-import { shortenDID } from '@/lib/ui'
+import React, { Fragment, useState } from "react";
+import {
+  Combobox,
+  ComboboxButton,
+  ComboboxInput,
+  ComboboxOption,
+  ComboboxOptions,
+  Transition,
+} from "@headlessui/react";
+import { ChevronUpDownIcon } from "@heroicons/react/20/solid";
+import { shortenDID } from "@/lib/ui";
 
 interface SpaceFinderProps {
-  spaces: Space[]
-  selected?: Space
-  setSelected?: (space: Space) => void
-  className?: string
+  spaces: Space[];
+  selected?: Space;
+  setSelected?: (space: Space) => void;
+  className?: string;
 }
 
-export function SpaceFinder ({
+export function SpaceFinder({
   spaces,
   selected,
   setSelected,
-  className = ''
+  className = "",
 }: SpaceFinderProps): JSX.Element {
-  const [query, setQuery] = useState('')
+  const [query, setQuery] = useState("");
   const filtered =
-    query === ''
+    query === ""
       ? spaces
       : spaces.filter((space: Space) =>
-        (space.name || space.did())
-          .toLowerCase()
-          .replace(/\s+/g, '')
-          .includes(query.toLowerCase().replace(/\s+/g, ''))
-      )
+          (space.name || space.did())
+            .toLowerCase()
+            .replace(/\s+/g, "")
+            .includes(query.toLowerCase().replace(/\s+/g, ""))
+        );
 
   return (
     <div className={`${className}`}>
@@ -38,77 +45,81 @@ export function SpaceFinder ({
         onChange={setSelected}
         by={(a, b) => a?.did() === b?.did()}
       >
-        <div className='relative mt-1'>
-          <div className='relative w-full overflow-hidden rounded-md bg-white text-left shadow-md'>
-            <Combobox.Input
-              className='w-full border-none py-2 pl-3 pr-10 text-sm text-gray-900'
-              displayValue={(space: Space) => space.name || shortenDID(space.did())}
-              onChange={(event) => { setQuery(event.target.value) }}
+        <div className="relative mt-1">
+          <div className="relative w-full overflow-hidden rounded-md bg-white text-left shadow-md">
+            <ComboboxInput
+              className="w-full border-none py-2 pl-3 pr-10 text-sm text-gray-900"
+              displayValue={(space: Space) =>
+                space.name || shortenDID(space.did())
+              }
+              onChange={(event) => {
+                setQuery(event.target.value);
+              }}
             />
-            <Combobox.Button className='absolute inset-y-0 right-0 flex items-center pl-1 pr-2'>
+            <ComboboxButton className="absolute inset-y-0 right-0 flex items-center pl-1 pr-2">
               <ChevronUpDownIcon
-                className='h-5 w-5 text-gray-400'
-                aria-hidden='true'
+                className="h-5 w-5 text-gray-400"
+                aria-hidden="true"
               />
-            </Combobox.Button>
+            </ComboboxButton>
           </div>
           <Transition
             as={Fragment}
-            leave='transition ease-in duration-100'
-            leaveFrom='opacity-100'
-            leaveTo='opacity-0'
-            afterLeave={() => { setQuery('') }}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+            afterLeave={() => {
+              setQuery("");
+            }}
           >
-            <Combobox.Options
-              className='absolute mt-1 max-h-96 w-full bg-white rounded-md pt-1 shadow-lg overflow-scroll z-10'
+            <ComboboxOptions
+              className="absolute mt-1 max-h-96 w-full bg-white rounded-md pt-1 shadow-lg overflow-scroll z-10"
               static
             >
-              {filtered.length === 0 && query !== ''
-                ? (
-                <div className='relative select-non py-2 px-4 font-mono text-sm text-red-500'>
+              {filtered.length === 0 && query !== "" ? (
+                <div className="relative select-non py-2 px-4 font-mono text-sm text-red-500">
                   (╯°□°)╯︵ ┻━┻
                 </div>
-                  )
-                : (
-                    filtered.map((space) => (
-                  <Combobox.Option
+              ) : (
+                filtered.map((space) => (
+                  <ComboboxOption
                     key={space.did()}
-                    className={({ active }) =>
+                    className={({ focus }) =>
                       `relative select-none py-2 pl-9 pr-4 ${
-                        active ? 'bg-hot-yellow-light cursor-pointer text-hot-red' : 'text-black'
+                        focus
+                          ? "bg-hot-yellow-light cursor-pointer text-hot-red"
+                          : "text-black"
                       }`
                     }
                     value={space}
                   >
-                    {({ selected, active }) => (
+                    {({ selected, focus }) => (
                       <>
                         <span
                           className={`block overflow-hidden text-ellipsis whitespace-nowrap ${
-                            selected ? 'font-medium' : ''
+                            selected ? "font-medium" : ""
                           }`}
                         >
                           {space.name || shortenDID(space.did())}
                         </span>
-                        {selected
-                          ? (
+                        {selected ? (
                           <span
                             className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
-                              active ? '' : ''
+                              focus ? "" : ""
                             }`}
                           >
                             ⁂
                           </span>
-                            )
-                          : null}
+                        ) : null}
                       </>
                     )}
-                  </Combobox.Option>
-                    ))
-                  )}
-            </Combobox.Options>
+                  </ComboboxOption>
+                ))
+              )}
+            </ComboboxOptions>
           </Transition>
         </div>
       </Combobox>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
### Description

- Move Headless UI `Combobox.XXXX` to `ComboxXXXX` components since it is deprecated, including its properties.